### PR TITLE
[um44] fix(ci): Build ultramarine-repos in bootstrap (#448)

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -30,6 +30,10 @@ jobs:
       - name: Build ultramarine-release
         run: |
           anda build -D "vendor Ultramarine Linux" -c ultramarine-${{ matrix.version }}-${{ matrix.arch }} ultramarine/release/pkg
+      
+      - name: Build ultramarine-repos
+        run: |
+          anda build -D "vendor Ultramarine Linux" -c ultramarine-${{ matrix.version }}-${{ matrix.arch }} ultramarine/repos/pkg
 
       - name: Upload packages to subatomic
         run: |


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [fix(ci): Build ultramarine-repos in bootstrap (#448)](https://github.com/Ultramarine-Linux/packages/pull/448)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)