### PR TITLE
fix(ci): Bootstrap build order

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -30,13 +30,13 @@ jobs:
         run: |
           dnf install -y anda-build/rpm/rpms/ultramarine-mock-configs*.rpm
 
-      - name: Build ultramarine-release
-        run: |
-          anda build -D "vendor Ultramarine Linux" -c ultramarine-${{ matrix.version }}-${{ matrix.arch }} ultramarine/release/pkg
-      
       - name: Build ultramarine-repos
         run: |
           anda build -D "vendor Ultramarine Linux" -c ultramarine-${{ matrix.version }}-${{ matrix.arch }} ultramarine/repos/pkg
+
+      - name: Build ultramarine-release
+        run: |
+          anda build -D "vendor Ultramarine Linux" -c ultramarine-${{ matrix.version }}-${{ matrix.arch }} ultramarine/release/pkg
 
       - name: Upload packages to subatomic
         run: |


### PR DESCRIPTION
This *should* work because of Anda's `createrepo_c` upon complete RPMs.