### PR TITLE
[um43] fix(ci): Bootstrap build order (#452)

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -27,13 +27,13 @@ jobs:
         run: |
           dnf install -y anda-build/rpm/rpms/ultramarine-mock-configs*.rpm
 
-      - name: Build ultramarine-release
-        run: |
-          anda build -D "vendor Ultramarine Linux" -c ultramarine-${{ matrix.version }}-${{ matrix.arch }} ultramarine/release/pkg
-      
       - name: Build ultramarine-repos
         run: |
           anda build -D "vendor Ultramarine Linux" -c ultramarine-${{ matrix.version }}-${{ matrix.arch }} ultramarine/repos/pkg
+
+      - name: Build ultramarine-release
+        run: |
+          anda build -D "vendor Ultramarine Linux" -c ultramarine-${{ matrix.version }}-${{ matrix.arch }} ultramarine/release/pkg
 
       - name: Upload packages to subatomic
         run: |


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um43`:
 - [fix(ci): Bootstrap build order (#452)](https://github.com/Ultramarine-Linux/packages/pull/452)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)