### PR TITLE
feat: Automatically update versions and releases for new Rawhide versions

### DIFF
--- a/andax/bump_extras.rhai
+++ b/andax/bump_extras.rhai
@@ -14,7 +14,7 @@ fn as_bodhi_ver(branch) {
         }
         return `EPEL-${release}`;
     } else if branch == "frawhide" {
-        return "F44";
+        return "F46";
     } else if branch.starts_with("f") {
         branch.crop(1);
         return `F${branch}`;

--- a/ultramarine/budgie-filesystem/anda.hcl
+++ b/ultramarine/budgie-filesystem/anda.hcl
@@ -3,4 +3,7 @@ project "pkg" {
         spec = "ultramarine-budgie-filesystem.spec"
         sources =  "."
     }
+    labels {
+      updbranch = 1
+    }
 }

--- a/ultramarine/budgie-filesystem/ultramarine-budgie-filesystem.spec
+++ b/ultramarine/budgie-filesystem/ultramarine-budgie-filesystem.spec
@@ -1,5 +1,5 @@
 Name:           ultramarine-budgie-filesystem
-Version:        %{?fedora}
+Version:        46
 Release:        1%{?dist}
 Summary:        Assets for Ultramarine Linux Budgie
 

--- a/ultramarine/budgie-filesystem/update.rhai
+++ b/ultramarine/budgie-filesystem/update.rhai
@@ -1,0 +1,3 @@
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::as_bodhi_ver(labels.branch));

--- a/ultramarine/fun/anda.hcl
+++ b/ultramarine/fun/anda.hcl
@@ -3,4 +3,7 @@ project pkg {
   rpm {
 	spec = "ultramarine-fun.spec"
   }
+  labels {
+    updbranch = 1
+  }
 }

--- a/ultramarine/fun/ultramarine-fun.spec
+++ b/ultramarine/fun/ultramarine-fun.spec
@@ -1,5 +1,5 @@
 Name:			ultramarine-fun
-Version:		%{?fedora}
+Version:		46
 Release:		1%?dist
 Summary:		Additional secret/hidden files for ultramarine Linux
 License:		MIT

--- a/ultramarine/fun/update.rhai
+++ b/ultramarine/fun/update.rhai
@@ -1,0 +1,3 @@
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::as_bodhi_ver(labels.branch));

--- a/ultramarine/gpg-keys/anda.hcl
+++ b/ultramarine/gpg-keys/anda.hcl
@@ -4,4 +4,7 @@ project "pkg" {
         spec = "ultramarine-gpg-keys.spec"
         sources =  "."
     }
+    labels {
+      updbranch = 1
+    }
 }

--- a/ultramarine/gpg-keys/ultramarine-gpg-keys.spec
+++ b/ultramarine/gpg-keys/ultramarine-gpg-keys.spec
@@ -1,7 +1,7 @@
 %undefine dist
 
 Name:           ultramarine-gpg-keys
-Version:        %{?fedora}
+Version:        46
 Release:        3%{?dist}
 Summary:        GPG keys for Ultramarine Linux
 Requires:       filesystem >= 3.18-6

--- a/ultramarine/gpg-keys/update.rhai
+++ b/ultramarine/gpg-keys/update.rhai
@@ -1,0 +1,3 @@
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::as_bodhi_ver(labels.branch));

--- a/ultramarine/langpacks/anda.hcl
+++ b/ultramarine/langpacks/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "ultramarine-langpacks.spec"
     }
+    labels {
+      updbranch = 1
+    }
 }

--- a/ultramarine/langpacks/ultramarine-langpacks.spec
+++ b/ultramarine/langpacks/ultramarine-langpacks.spec
@@ -1,7 +1,7 @@
 # ? https://src.fedoraproject.org/rpms/langpacks/tree/rawhide
 
 Name:      ultramarine-langpacks
-Version:   %{?fedora}
+Version:   46
 Release:   1%{?dist}
 Summary:   Langpacks meta-package
 

--- a/ultramarine/langpacks/update.rhai
+++ b/ultramarine/langpacks/update.rhai
@@ -1,0 +1,3 @@
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::as_bodhi_ver(labels.branch));

--- a/ultramarine/logos/anda.hcl
+++ b/ultramarine/logos/anda.hcl
@@ -3,4 +3,7 @@ project "pkg" {
         spec = "ultramarine-logos.spec"
         sources =  "."
     }
+    labels {
+      updbranch = 1
+    }
 }

--- a/ultramarine/logos/ultramarine-logos.spec
+++ b/ultramarine/logos/ultramarine-logos.spec
@@ -1,7 +1,7 @@
 Name:          ultramarine-logos
 %define        _alt_name fedora-logos
 Summary:       Icons and pictures related to Ultramarine Linux
-Version:       %{?fedora}
+Version:       46
 %define        _release 1%{?dist}
 Release:       1%{?dist}
 URL:           https://github.com/Ultramarine-Linux/logos

--- a/ultramarine/logos/update.rhai
+++ b/ultramarine/logos/update.rhai
@@ -1,0 +1,3 @@
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::as_bodhi_ver(labels.branch));

--- a/ultramarine/pipewire-systemd-mask/anda.hcl
+++ b/ultramarine/pipewire-systemd-mask/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
 	rpm {
 		spec = "pipewire-systemd-mask.spec"
 	}
+	labels {
+	  updbranch = 1
+	}
 }

--- a/ultramarine/pipewire-systemd-mask/pipewire-systemd-mask.spec
+++ b/ultramarine/pipewire-systemd-mask/pipewire-systemd-mask.spec
@@ -1,5 +1,5 @@
 Name:			pipewire-systemd-mask
-Version:		%{?fedora}
+Version:		46
 Release:		1%?dist
 Summary:		Mask pipewire.service and pipewire.socket
 License:		MIT

--- a/ultramarine/pipewire-systemd-mask/update.rhai
+++ b/ultramarine/pipewire-systemd-mask/update.rhai
@@ -1,0 +1,3 @@
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::as_bodhi_ver(labels.branch));

--- a/ultramarine/release/anda.hcl
+++ b/ultramarine/release/anda.hcl
@@ -4,4 +4,7 @@ project "pkg" {
         spec = "ultramarine-release.spec"
         sources = "."
     }
+    labels {
+      updbranch = 1
+    }
 }

--- a/ultramarine/release/ultramarine-release.spec
+++ b/ultramarine/release/ultramarine-release.spec
@@ -3,7 +3,7 @@
 %global release_name Cheetah
 %global fedora_codename Rawhide
 %global codename cheetah
-%define dist_version %{?fedora}
+%define dist_version 46
 
 %define xfce_conf_commit 4ee924020b97cf2b4d30510641a2f63ef06ed148
 

--- a/ultramarine/release/update.rhai
+++ b/ultramarine/release/update.rhai
@@ -1,0 +1,7 @@
+import "andax/bump_extras.rhai" as bump;
+
+rpm.global("dist_version", bump::as_bodhi_ver(labels.branch));
+
+if rpm.changed() {
+  rpm.release();
+}

--- a/ultramarine/repos/anda.hcl
+++ b/ultramarine/repos/anda.hcl
@@ -3,4 +3,7 @@ project "pkg" {
         spec = "repos.spec"
         sources =  "."
     }
+    labels {
+      updbranch = 1
+    }
 }

--- a/ultramarine/repos/repos.spec
+++ b/ultramarine/repos/repos.spec
@@ -1,4 +1,4 @@
-%global _dist_version %{?fedora}
+%global _dist_version 46
 
 Name: ultramarine-repos
 Version: %{_dist_version}

--- a/ultramarine/repos/update.rhai
+++ b/ultramarine/repos/update.rhai
@@ -1,0 +1,7 @@
+import "andax/bump_extras.rhai" as bump;
+
+rpm.global("_dist_version", bump::as_bodhi_ver(labels.branch));
+
+if rpm.changed() {
+  rpm.release();
+}

--- a/ultramarine/shell-config/anda.hcl
+++ b/ultramarine/shell-config/anda.hcl
@@ -4,4 +4,7 @@ project "pkg" {
         spec = "ultramarine-shell-config.spec"
         sources =  "."
     }
+    labels {
+      updbranch = 1
+    }
 }

--- a/ultramarine/shell-config/ultramarine-shell-config.spec
+++ b/ultramarine/shell-config/ultramarine-shell-config.spec
@@ -1,5 +1,5 @@
 Name:           ultramarine-shell-config
-Version:        %{?fedora}
+Version:        46
 Release:        2%{?dist}
 Summary:        Shell configuration for Ultramarine Linux
 License:        MIT

--- a/ultramarine/shell-config/update.rhai
+++ b/ultramarine/shell-config/update.rhai
@@ -1,0 +1,3 @@
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::as_bodhi_ver(labels.branch));

--- a/ultramarine/taidan-ultramarine-configs/anda.hcl
+++ b/ultramarine/taidan-ultramarine-configs/anda.hcl
@@ -3,4 +3,7 @@ project pkg {
   rpm {
     spec = "taidan-ultramarine-configs.spec"
   }
+  labels {
+    updbranch = 1
+  }
 }

--- a/ultramarine/taidan-ultramarine-configs/taidan-ultramarine-configs.spec
+++ b/ultramarine/taidan-ultramarine-configs/taidan-ultramarine-configs.spec
@@ -1,5 +1,5 @@
 Name:           taidan-ultramarine-configs
-Version:        44
+Version:        46
 Release:        5%?dist
 Summary:        Taidan configuration for Ultramarine
 License:        (MIT AND GPL-3.0-or-later)

--- a/ultramarine/taidan-ultramarine-configs/update.rhai
+++ b/ultramarine/taidan-ultramarine-configs/update.rhai
@@ -1,0 +1,3 @@
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::as_bodhi_ver(labels.branch));

--- a/ultramarine/ultramarine-raw-filesystem/anda.hcl
+++ b/ultramarine/ultramarine-raw-filesystem/anda.hcl
@@ -3,4 +3,7 @@ project "pkg" {
         spec = "ultramarine-raw-filesystem.spec"
         sources =  "."
     }
+    labels {
+      updbranch = 1
+    }
 }

--- a/ultramarine/ultramarine-raw-filesystem/ultramarine-raw-filesystem.spec
+++ b/ultramarine/ultramarine-raw-filesystem/ultramarine-raw-filesystem.spec
@@ -1,5 +1,5 @@
 Name:           ultramarine-raw-filesystem
-Version:        %{?fedora}
+Version:        46
 Release:        1%{?dist}
 Summary:        systemd-repart config to automatically extend the root filesystem on raw images
 URL:            ultramarine-linux.org

--- a/ultramarine/ultramarine-raw-filesystem/update.rhai
+++ b/ultramarine/ultramarine-raw-filesystem/update.rhai
@@ -1,0 +1,3 @@
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::as_bodhi_ver(labels.branch));

--- a/ultramarine/ultramarine-system-configs/anda.hcl
+++ b/ultramarine/ultramarine-system-configs/anda.hcl
@@ -3,4 +3,7 @@ project "pkg" {
         spec = "ultramarine-system-configs.spec"
         sources =  "."
     }
+    labels {
+      updbranch = 1
+    }
 }

--- a/ultramarine/ultramarine-system-configs/ultramarine-system-configs.spec
+++ b/ultramarine/ultramarine-system-configs/ultramarine-system-configs.spec
@@ -1,5 +1,5 @@
 Name:           ultramarine-system-configs
-Version:        %{?fedora}
+Version:        46
 Release:        1%{?dist}
 Summary:        Various configuration files for a more comfortable Ultramarine desktop experience
 BuildArch:      noarch

--- a/ultramarine/ultramarine-system-configs/update.rhai
+++ b/ultramarine/ultramarine-system-configs/update.rhai
@@ -1,0 +1,3 @@
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::as_bodhi_ver(labels.branch));

--- a/ultramarine/ultramarine-wsl-filesystem/anda.hcl
+++ b/ultramarine/ultramarine-wsl-filesystem/anda.hcl
@@ -2,4 +2,7 @@ project "pkg" {
     rpm {
         spec = "ultramarine-wsl-filesystem.spec"
     }
+    labels {
+      updbranch = 1
+    }
 }

--- a/ultramarine/ultramarine-wsl-filesystem/ultramarine-wsl-filesystem.spec
+++ b/ultramarine/ultramarine-wsl-filesystem/ultramarine-wsl-filesystem.spec
@@ -4,7 +4,7 @@
 # - https://salsa.debian.org/debian/WSL
 
 Name:           ultramarine-wsl-filesystem
-Version:        %{?fedora}
+Version:        46
 Release:        1%{?dist}
 Summary:        Ultramarine for WSL configuration files
 URL:            ultramarine-linux.org

--- a/ultramarine/ultramarine-wsl-filesystem/update.rhai
+++ b/ultramarine/ultramarine-wsl-filesystem/update.rhai
@@ -1,0 +1,3 @@
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::as_bodhi_ver(labels.branch));


### PR DESCRIPTION
Probably shouldn't be synced to UM44 and below, should be synced to 45 once branched.

I know nothing builds, #460 should fix that but ideally merge this first so versions and releases are reset.