### PR TITLE
fix(ci): Use Fedora Mock configs unless necessary

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -20,24 +20,19 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install build dependencies
-        run: dnf builddep -y ultramarine/ultramarine-mock-configs/*.spec
-
-      # Must be built using Fedora's Mock configs first so it is available for subsequent builds
-      - name: Build ultramarine-release
-        run: |
-          anda build -D "vendor Ultramarine Linux" -D "dist .um${{ matrix.version }}" -c fedora-${{ matrix.version }}-${{ matrix.arch }} ultramarine/release/pkg
+        run: dnf builddep -y ultramarine/{ultramarine-mock-configs,release,repos}/*.spec
 
       - name: Build ultramarine-mock-configs
         run: |
           anda build -D "vendor Ultramarine Linux" -D "dist .um${{ matrix.version }}" -c fedora-${{ matrix.version }}-${{ matrix.arch }} ultramarine/ultramarine-mock-configs/pkg
 
-      - name: Install ultramarine-mock-configs
-        run: |
-          dnf install -y anda-build/rpm/rpms/ultramarine-mock-configs*.rpm
-
       - name: Build ultramarine-repos
         run: |
-          anda build -D "vendor Ultramarine Linux" -c ultramarine-${{ matrix.version }}-${{ matrix.arch }} ultramarine/repos/pkg
+          anda build -D "vendor Ultramarine Linux" -D "dist .um${{ matrix.version }}" -c fedora-${{ matrix.version }}-${{ matrix.arch }} ultramarine/repos/pkg
+
+      - name: Build ultramarine-release
+        run: |
+          anda build -D "vendor Ultramarine Linux" -D "dist .um${{ matrix.version }}" -c fedora-${{ matrix.version }}-${{ matrix.arch }} ultramarine/release/pkg
 
       - name: Upload packages to subatomic
         run: |


### PR DESCRIPTION
This is very cursed but for these packages should be fine.

Mock configs install step will have to be revived in the event we add more intense packages but otherwise yeah.

Ideally merge after #459 and after the branch update has run once.