### PR TITLE
[umrawhide] fix(release): move inline comment to new line (#457)

### DIFF
--- a/ultramarine/release/89-ultramarine-default.preset
+++ b/ultramarine/release/89-ultramarine-default.preset
@@ -10,6 +10,7 @@ disable flatpak-add-fedora-repos.service
 enable polycrystal.service
 
 # Chromebook keyboard maps
-enable keyd.service # hopefully will be replaced by croskbd soon
+enable keyd.service
+# keyd hopefully will be replaced by croskbd soon
 enable cros-keyboard-map.service
 enable croskbd.service

--- a/ultramarine/release/ultramarine-release.spec
+++ b/ultramarine/release/ultramarine-release.spec
@@ -54,7 +54,7 @@
 Summary:	Ultramarine Linux release files
 Name:		ultramarine-release
 Version:	%{dist_version}
-Release:	9%{?dist}
+Release:	10%{?dist}
 License:	MIT
 Source0:	LICENSE
 URL:        https://ultramarine-linux.org


### PR DESCRIPTION
# Backport

This will backport the following commits from `um44` to `umrawhide`:
 - [fix(release): move inline comment to new line (#457)](https://github.com/Ultramarine-Linux/packages/pull/457)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)