### PR TITLE
[um44] fix(ultramarine-gpg-keys): Remove `%dir` (#464)

### DIFF
--- a/ultramarine/gpg-keys/ultramarine-gpg-keys.spec
+++ b/ultramarine/gpg-keys/ultramarine-gpg-keys.spec
@@ -1,8 +1,8 @@
 %undefine dist
 
 Name:           ultramarine-gpg-keys
-Version:        %{?fedora}
-Release:        3%{?dist}
+Version:        44
+Release:        4%{?dist}
 Summary:        GPG keys for Ultramarine Linux
 Requires:       filesystem >= 3.18-6
 
@@ -39,5 +39,4 @@ install -d -m 755 $RPM_BUILD_ROOT/etc/pki/rpm-gpg
 install -m 644 %{_sourcedir}/RPM-GPG-KEY* $RPM_BUILD_ROOT/etc/pki/rpm-gpg/
 
 %files
-%dir /etc/pki/rpm-gpg
 /etc/pki/rpm-gpg/RPM-GPG-KEY-*


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [fix(ultramarine-gpg-keys): Remove `%dir` (#464)](https://github.com/Ultramarine-Linux/packages/pull/464)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)