### PR TITLE
[um44] comps: pull in ultramarine-bookmarks (#470)

### DIFF
--- a/comps.xml
+++ b/comps.xml
@@ -57,6 +57,7 @@
       <packagereq type="default">ultramarine-fun</packagereq>
       <packagereq type="default">ultramarine-system-configs-core</packagereq>
       <packagereq type="default">ultramarine-repos</packagereq>
+      <packagereq type="default">ultramarine-bookmarks</packagereq>
       <packagereq type="default">git</packagereq>
       <packagereq type="default">vim</packagereq>
       <packagereq type="default">nano</packagereq>


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [comps: pull in ultramarine-bookmarks (#470)](https://github.com/Ultramarine-Linux/packages/pull/470)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)