### PR TITLE
[um44] add sl to ultramarine product common (#473)

### DIFF
--- a/comps.xml
+++ b/comps.xml
@@ -71,6 +71,7 @@
       <packagereq type="default">NetworkManager-tui</packagereq>
       <packagereq type="default">zstd</packagereq>
       <packagereq type="default">lm_sensors</packagereq>
+      <packagereq type="default">sl</packagereq>
     </packagelist>
   </group>
   <group>


### PR DESCRIPTION
# Backport

This will backport the following commits from `umrawhide` to `um44`:
 - [add sl to ultramarine product common (#473)](https://github.com/Ultramarine-Linux/packages/pull/473)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)